### PR TITLE
chore: Feedbacks and remove leftovers from fp-ts

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,12 @@
+{
+    "linter": {
+        "rules": {
+            "suspicious": {
+                "noShadowRestrictedNames": "off"
+            },
+            "style": {
+                "useImportType": "off"
+            }
+        }
+    }
+}

--- a/src/exo2 - Combinators/exo2.exercise.ts
+++ b/src/exo2 - Combinators/exo2.exercise.ts
@@ -109,7 +109,7 @@ export const invalidAttackerFailure = Failure.builder(
 // recommended to break those down into smaller private functions that can be
 // reused instead of doing one big `pipe` for each.
 //
-// HINT: `Either` has a special constructor `fromPredicate` that can accept
+// HINT: `Either` has a special constructor `liftPredicate` that can accept
 // a type guard such as `isWarrior` to help with type inference.
 //
 // HINT: Sequentially check for various possible errors is one of the most


### PR DESCRIPTION
**Contents**

- Changing `fromPredicate` to `liftPredicate` as the later doesn't exist in effect, and that is misleading in the exercise.

- Also adding some biome exceptions to have no linting errors on imports for Effect types that are used as Objects later on and Array that is a shadow of the native Array but is expected to be used in the exercise.